### PR TITLE
feat(canvas): add file/folder tools; implement list_course_files

### DIFF
--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -65,3 +65,50 @@ export interface CanvasPlannerItem {
   };
   html_url?: string;
 }
+
+export interface CanvasFile {
+  id: number;
+  uuid?: string;
+  folder_id?: number;
+  display_name: string;
+  filename: string;
+  'content-type'?: string;
+  url?: string;
+  size?: number;
+  created_at?: string;
+  updated_at?: string;
+  unlock_at?: string | null;
+  locked?: boolean;
+  hidden?: boolean;
+  lock_at?: string | null;
+  hidden_for_user?: boolean;
+  thumbnail_url?: string | null;
+  modified_at?: string;
+  mime_class?: string;
+  media_entry_id?: string | null;
+  locked_for_user?: boolean;
+  lock_explanation?: string;
+}
+
+export interface CanvasFolder {
+  id: number;
+  name: string;
+  full_name?: string;
+  context_id?: number;
+  context_type?: string;
+  parent_folder_id?: number | null;
+  created_at?: string;
+  updated_at?: string;
+  locked?: boolean;
+  folders_url?: string;
+  files_url?: string;
+  files_count?: number;
+  folders_count?: number;
+  hidden?: boolean;
+  locked_for_user?: boolean;
+  for_submissions?: boolean;
+}
+
+export interface CanvasFilePublicUrl {
+  public_url: string;
+}

--- a/src/tools/mappers.ts
+++ b/src/tools/mappers.ts
@@ -10,7 +10,7 @@ import {
   Announcement,
   Assignment,
   Course,
-  File,
+  FileResource,
   Folder,
   SubmissionState,
   UpcomingItem
@@ -152,7 +152,7 @@ export function normalizePlannerItem(
   return undefined;
 }
 
-export function mapFile(raw: CanvasFile): File {
+export function mapFile(raw: CanvasFile): FileResource {
   return {
     id: raw.id,
     uuid: raw.uuid,

--- a/src/tools/mappers.ts
+++ b/src/tools/mappers.ts
@@ -2,12 +2,16 @@ import {
   CanvasAnnouncement,
   CanvasAssignment,
   CanvasCourse,
+  CanvasFile,
+  CanvasFolder,
   CanvasSubmission
 } from '../canvas/types.js';
 import {
   Announcement,
   Assignment,
   Course,
+  File,
+  Folder,
   SubmissionState,
   UpcomingItem
 } from './schemas.js';
@@ -146,4 +150,43 @@ export function normalizePlannerItem(
   }
 
   return undefined;
+}
+
+export function mapFile(raw: CanvasFile): File {
+  return {
+    id: raw.id,
+    uuid: raw.uuid,
+    folder_id: raw.folder_id,
+    display_name: raw.display_name,
+    filename: raw.filename,
+    content_type: raw['content-type'],
+    url: raw.url,
+    size: raw.size,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    locked: raw.locked,
+    hidden: raw.hidden,
+    locked_for_user: raw.locked_for_user,
+    thumbnail_url: raw.thumbnail_url,
+    mime_class: raw.mime_class
+  };
+}
+
+export function mapFolder(raw: CanvasFolder): Folder {
+  return {
+    id: raw.id,
+    name: raw.name,
+    full_name: raw.full_name,
+    context_id: raw.context_id,
+    context_type: raw.context_type,
+    parent_folder_id: raw.parent_folder_id,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    locked: raw.locked,
+    folders_count: raw.folders_count,
+    files_count: raw.files_count,
+    hidden: raw.hidden,
+    locked_for_user: raw.locked_for_user,
+    for_submissions: raw.for_submissions
+  };
 }

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -68,3 +68,63 @@ export const listAnnouncementsOutputSchema = z.object({
 export const listUpcomingOutputSchema = z.object({
   upcoming: z.array(upcomingItemSchema)
 });
+
+export const fileSchema = z.object({
+  id: z.number(),
+  uuid: z.string().optional(),
+  folder_id: z.number().optional(),
+  display_name: z.string(),
+  filename: z.string(),
+  content_type: z.string().optional(),
+  url: z.string().optional(),
+  size: z.number().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  locked: z.boolean().optional(),
+  hidden: z.boolean().optional(),
+  locked_for_user: z.boolean().optional(),
+  thumbnail_url: z.string().nullable().optional(),
+  mime_class: z.string().optional()
+});
+
+export type File = z.infer<typeof fileSchema>;
+
+export const folderSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  full_name: z.string().optional(),
+  context_id: z.number().optional(),
+  context_type: z.string().optional(),
+  parent_folder_id: z.number().nullable().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  locked: z.boolean().optional(),
+  folders_count: z.number().optional(),
+  files_count: z.number().optional(),
+  hidden: z.boolean().optional(),
+  locked_for_user: z.boolean().optional(),
+  for_submissions: z.boolean().optional()
+});
+
+export type Folder = z.infer<typeof folderSchema>;
+
+export const listFilesOutputSchema = z.object({
+  files: z.array(fileSchema)
+});
+
+export const getFileOutputSchema = z.object({
+  file: fileSchema
+});
+
+export const getFileDownloadUrlOutputSchema = z.object({
+  file_id: z.number(),
+  download_url: z.string()
+});
+
+export const listFoldersOutputSchema = z.object({
+  folders: z.array(folderSchema)
+});
+
+export const getFolderOutputSchema = z.object({
+  folder: folderSchema
+});

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -87,7 +87,10 @@ export const fileSchema = z.object({
   mime_class: z.string().optional()
 });
 
-export type File = z.infer<typeof fileSchema>;
+export type FileResource = z.infer<typeof fileSchema>;
+
+/** @deprecated Use FileResource instead to avoid collision with built-in DOM File type */
+export type File = FileResource;
 
 export const folderSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
- Document new File & Folder tools in README:
  list_user_files, list_course_files, list_folder_files, get_file,
  get_file_download_url, list_user_folders, list_course_folders, get_folder
- Add data contracts for File and Folder, plus "File Download" section
  explaining temporary signed URLs and usage constraints
- Implement server registration for list_course_files with optional
  search_term, content_types, sort, and order parameters
- Improves MCP coverage for read-only file/folder access and
  enables direct download workflows while keeping JSON contracts consistent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools to browse and retrieve files and folders (list user/course/folder files and folders, get file/folder details, obtain file download URLs).
  * Introduced a file-access prompt to guide users through locating and downloading course files.

* **Documentation**
  * Updated Tool Reference and Prompt Reference with new file/folder tools and the canvas.file_access prompt.
  * Added File and Folder data contracts and expanded File Download guidance and Quickstart examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->