### PR TITLE
fix: handle nullable folder booleans from Canvas

### DIFF
--- a/src/__tests__/timezone.test.ts
+++ b/src/__tests__/timezone.test.ts
@@ -117,4 +117,24 @@ describe('mappers', () => {
     expect(file.created_at).toBe('2024-06-30T17:00:00-07:00');
     expect(file.updated_at).toBe('2024-06-30T18:00:00-07:00');
   });
+
+  it('normalizes nullable folder booleans from Canvas', async () => {
+    const envModule = await import('../core/env.js');
+    envModule.resetEnvCacheForTesting();
+    const mappers = await import('../tools/mappers.js');
+
+    const folder = mappers.mapFolder({
+      id: 42,
+      name: 'Uploads',
+      hidden: null,
+      locked: null,
+      locked_for_user: null,
+      for_submissions: null
+    });
+
+    expect(folder.hidden).toBeUndefined();
+    expect(folder.locked).toBeUndefined();
+    expect(folder.locked_for_user).toBeUndefined();
+    expect(folder.for_submissions).toBeUndefined();
+  });
 });

--- a/src/__tests__/timezone.test.ts
+++ b/src/__tests__/timezone.test.ts
@@ -118,6 +118,25 @@ describe('mappers', () => {
     expect(file.updated_at).toBe('2024-06-30T18:00:00-07:00');
   });
 
+  it('normalizes nullable file booleans from Canvas', async () => {
+    const envModule = await import('../core/env.js');
+    envModule.resetEnvCacheForTesting();
+    const mappers = await import('../tools/mappers.js');
+
+    const file = mappers.mapFile({
+      id: 7,
+      display_name: 'x',
+      filename: 'x.txt',
+      locked: null,
+      hidden: null,
+      locked_for_user: null
+    });
+
+    expect(file.locked).toBeUndefined();
+    expect(file.hidden).toBeUndefined();
+    expect(file.locked_for_user).toBeUndefined();
+  });
+
   it('normalizes nullable folder booleans from Canvas', async () => {
     const envModule = await import('../core/env.js');
     envModule.resetEnvCacheForTesting();

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -78,15 +78,15 @@ export interface CanvasFile {
   created_at?: string;
   updated_at?: string;
   unlock_at?: string | null;
-  locked?: boolean;
-  hidden?: boolean;
+  locked?: boolean | null;
+  hidden?: boolean | null;
   lock_at?: string | null;
-  hidden_for_user?: boolean;
+  hidden_for_user?: boolean | null;
   thumbnail_url?: string | null;
   modified_at?: string;
   mime_class?: string;
   media_entry_id?: string | null;
-  locked_for_user?: boolean;
+  locked_for_user?: boolean | null;
   lock_explanation?: string;
 }
 

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -99,14 +99,14 @@ export interface CanvasFolder {
   parent_folder_id?: number | null;
   created_at?: string;
   updated_at?: string;
-  locked?: boolean;
+  locked?: boolean | null;
   folders_url?: string;
   files_url?: string;
   files_count?: number;
   folders_count?: number;
-  hidden?: boolean;
-  locked_for_user?: boolean;
-  for_submissions?: boolean;
+  hidden?: boolean | null;
+  locked_for_user?: boolean | null;
+  for_submissions?: boolean | null;
 }
 
 export interface CanvasFilePublicUrl {

--- a/src/tools/mappers.ts
+++ b/src/tools/mappers.ts
@@ -169,9 +169,9 @@ export function mapFile(raw: CanvasFile): FileResource {
     size: raw.size,
     created_at: toCanvasTimezone(raw.created_at) ?? raw.created_at,
     updated_at: toCanvasTimezone(raw.updated_at) ?? raw.updated_at,
-    locked: raw.locked,
-    hidden: raw.hidden,
-    locked_for_user: raw.locked_for_user,
+    locked: asBooleanOrUndefined(raw.locked),
+    hidden: asBooleanOrUndefined(raw.hidden),
+    locked_for_user: asBooleanOrUndefined(raw.locked_for_user),
     thumbnail_url: raw.thumbnail_url,
     mime_class: raw.mime_class
   };

--- a/src/tools/mappers.ts
+++ b/src/tools/mappers.ts
@@ -21,6 +21,10 @@ function normalizeTerm(term?: string | null): string {
   return term?.trim() ?? '';
 }
 
+function asBooleanOrUndefined(value?: boolean | null): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
 function computeSubmissionState(submission?: CanvasSubmission): SubmissionState {
   if (!submission) {
     return 'unsubmitted';
@@ -183,11 +187,11 @@ export function mapFolder(raw: CanvasFolder): Folder {
     parent_folder_id: raw.parent_folder_id,
     created_at: toCanvasTimezone(raw.created_at) ?? raw.created_at,
     updated_at: toCanvasTimezone(raw.updated_at) ?? raw.updated_at,
-    locked: raw.locked,
+    locked: asBooleanOrUndefined(raw.locked),
     folders_count: raw.folders_count,
     files_count: raw.files_count,
-    hidden: raw.hidden,
-    locked_for_user: raw.locked_for_user,
-    for_submissions: raw.for_submissions
+    hidden: asBooleanOrUndefined(raw.hidden),
+    locked_for_user: asBooleanOrUndefined(raw.locked_for_user),
+    for_submissions: asBooleanOrUndefined(raw.for_submissions)
   };
 }


### PR DESCRIPTION
## Summary
Fixes the `get_folder` tool failure seen in prod when Canvas returns `null` for folder boolean fields.

### What changed
- Normalize nullable folder booleans (`hidden`, `locked`, `locked_for_user`, `for_submissions`) to `undefined` in `mapFolder`.
- Update `CanvasFolder` type to allow `boolean | null` for those fields.
- Add regression test covering null boolean normalization in `timezone.test.ts` mapper tests.

### Why
Canvas docs model these as booleans, but runtime responses can still contain `null` for some records. Our Zod output schema expects booleans (optional), so passing raw null caused `get_folder` to return an MCP error.

### Validation
- `npm test` ✅ (21 tests)
- `npm run build` ✅
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xiyaowang0519/canvas_mcp/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
